### PR TITLE
Improve indexing performance by limiting POST requests

### DIFF
--- a/indexer/cron.py
+++ b/indexer/cron.py
@@ -13,11 +13,12 @@ class BaseCron(CronJobBase):
     def do(self):
         start = datetime.now()
         action = "Full" if self.clean else "Incremental"
-        print("{} indexing of {} records started at {}".format(action, self.object_type, start))
+        object_type = self.object_type if self.object_type else "All"
+        print("{} indexing of {} records started at {}".format(action, object_type, start))
         indexed = Indexer().add(object_type=self.object_type, clean=self.clean)
         end = datetime.now()
         print("{} records indexed in {}".format(len(indexed), end - start))
-        print("{} index of {} records complete at {}\n".format(action, self.object_type, end))
+        print("{} index of {} records complete at {}\n".format(action, object_type, end))
 
 
 class IndexAll(BaseCron):


### PR DESCRIPTION
Now only POSTs back to Pisces once an index run has been completed, or if an exception is encountered. This should substantially speed up indexing.

fixes #95 
