### PR TITLE
chore: set python version override

### DIFF
--- a/.github/workflows/python-full-suite-dependencies.yml
+++ b/.github/workflows/python-full-suite-dependencies.yml
@@ -11,5 +11,7 @@ permissions:
 jobs:
   automatic-release:
     uses: RockefellerArchiveCenter/.github/.github/workflows/python-full-suite-dependencies.yml@base
+    with:
+      python-version: "3.10"
     secrets:
       ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}


### PR DESCRIPTION
In dependencies updates github actions workflow, use 3.10 instead of 3.12 from centralized workflow.